### PR TITLE
Collapsing header

### DIFF
--- a/StretchyScrollApp/StretchyScrollApp/ContentView.swift
+++ b/StretchyScrollApp/StretchyScrollApp/ContentView.swift
@@ -49,6 +49,7 @@ struct ContentView: View {
             }
             .tag(2)
         }
+        .edgesIgnoringSafeArea(.top)
     }
 }
 

--- a/StretchyScrollApp/StretchyScrollApp/ScrollViewExample.swift
+++ b/StretchyScrollApp/StretchyScrollApp/ScrollViewExample.swift
@@ -15,7 +15,11 @@ struct ScrollViewExample: View {
     var staticHeight: CGFloat = 84
     var extraHeight: CGFloat = 240
     
-    var maxHeaderHeight: CGFloat { staticHeight + extraHeight }
+    private var maxHeaderHeight: CGFloat { staticHeight + extraHeight }
+    
+    private func contentOffset(in geometry: GeometryProxy) -> CGFloat {
+        min(headerHeight(in: geometry), maxHeaderHeight + geometry.safeAreaInsets.top)
+    }
     
     private func headerHeight(in geometry: GeometryProxy) -> CGFloat {
         max(self.offset - 32, staticHeight) + geometry.safeAreaInsets.top
@@ -30,9 +34,9 @@ struct ScrollViewExample: View {
                 
                 ScrollViewContentView(offset: self.headerHeight(in: geometry))
                     .coordinateSpace(name: "myZstack")
-                    .offset(y: min(self.headerHeight(in: geometry),
-                                   self.maxHeaderHeight + geometry.safeAreaInsets.top))
+                    .offset(y: self.contentOffset(in: geometry))
                     .zIndex(1)
+                    .padding(.bottom, self.contentOffset(in: geometry))
                 
             }
             .onPreferenceChange(ScrollOffsetPreferenceKey.self) { delta in

--- a/StretchyScrollApp/StretchyScrollApp/ScrollViewExample.swift
+++ b/StretchyScrollApp/StretchyScrollApp/ScrollViewExample.swift
@@ -14,23 +14,24 @@ struct ScrollViewExample: View {
     
     var staticHeight: CGFloat = 84
     var extraHeight: CGFloat = 240
-    var headerHeight: CGFloat {
-        max(self.offset - 32, staticHeight)
-    }
-    var maxHeaderHeight: CGFloat {
-        staticHeight + extraHeight
+    
+    var maxHeaderHeight: CGFloat { staticHeight + extraHeight }
+    
+    private func headerHeight(in geometry: GeometryProxy) -> CGFloat {
+        max(self.offset - 32, staticHeight) + geometry.safeAreaInsets.top
     }
     
     var body: some View {
         GeometryReader { geometry in
             ZStack(alignment: .top) {
                 ScrollViewHeaderView(offset: self.offset,
-                                     desiredHeight: self.headerHeight + geometry.safeAreaInsets.top)
+                                     desiredHeight: self.headerHeight(in: geometry))
                     .zIndex(2)
                 
-                ScrollViewContentView(offset: self.headerHeight)
+                ScrollViewContentView(offset: self.headerHeight(in: geometry))
                     .coordinateSpace(name: "myZstack")
-                    .offset(y: min(self.headerHeight, self.maxHeaderHeight) + geometry.safeAreaInsets.top)
+                    .offset(y: min(self.headerHeight(in: geometry),
+                                   self.maxHeaderHeight + geometry.safeAreaInsets.top))
                     .zIndex(1)
                 
             }

--- a/StretchyScrollApp/StretchyScrollApp/ScrollViewExample.swift
+++ b/StretchyScrollApp/StretchyScrollApp/ScrollViewExample.swift
@@ -8,7 +8,8 @@
 
 import SwiftUI
 
-struct StacyHeader<Header: View>: ViewModifier {
+/// Modifier that wraps the main view, and adds a header between min and max height
+struct StretcyHeader<Header: View>: ViewModifier {
     
     @State private var offset: CGFloat
         
@@ -53,6 +54,7 @@ struct StacyHeader<Header: View>: ViewModifier {
     }
 }
 
+/// Preference key reserved for offset
 struct ScrollOffsetPreferenceKey: PreferenceKey, Equatable {
     static var defaultValue: CGFloat = 0
         
@@ -60,9 +62,11 @@ struct ScrollOffsetPreferenceKey: PreferenceKey, Equatable {
         value += nextValue()
     }
     
+    /// the position of the observed elemet in the parent
     var correction: CGFloat = 0
 }
 
+/// ViewModifier extension to wrap any view in stolling content
 extension ScrollOffsetPreferenceKey: ViewModifier {
     
     func body(content: Content) -> some View {
@@ -79,7 +83,7 @@ struct ScrollViewExample: View {
 
     var body: some View {
         ScrollViewContentView()
-            .modifier(StacyHeader(staticHeight: 64, extraHeight: 100, content: { desiredHeight in
+            .modifier(StretcyHeader(staticHeight: 64, extraHeight: 100, content: { desiredHeight in
                 ScrollViewHeaderView(desiredHeight: desiredHeight)
             }))
     }

--- a/StretchyScrollApp/StretchyScrollApp/ScrollViewExample.swift
+++ b/StretchyScrollApp/StretchyScrollApp/ScrollViewExample.swift
@@ -80,19 +80,21 @@ extension ScrollOffsetPreferenceKey: ViewModifier {
 }
 
 struct ScrollViewExample: View {
-
+    
     var body: some View {
-        ScrollViewContentView()
-            .modifier(StretcyHeader(staticHeight: 64, extraHeight: 100, content: { desiredHeight in
-                ScrollViewHeaderView(desiredHeight: desiredHeight)
-            }))
+        ZStack  {
+            ScrollViewContentView()
+        }
+        .modifier(StretcyHeader(staticHeight: 64, extraHeight: 100, content: { desiredHeight in
+            ScrollViewHeaderView(desiredHeight: desiredHeight)
+        }))
     }
 }
 
 struct ScrollViewHeaderView: View {
     
     var desiredHeight: CGFloat
-
+    
     var body: some View {
         GeometryReader { proxy in
             ZStack {
@@ -120,17 +122,23 @@ struct ScrollViewHeaderView: View {
 }
 
 struct ScrollViewContentView: View {
+    
+    @State private var topPadding: CGFloat = 28
         
     var body: some View {
         Form {
-            Text("Top content")
-                .modifier(ScrollOffsetPreferenceKey(correction: 32))
-            
-            Section(header: Text("0")) {
+            Section(header: Text("0").padding(.top, topPadding)) {
                 NavigationLink(destination: DetailView(title: "Nav")) {
                     Text("Navigation link")
+                        .modifier(ScrollOffsetPreferenceKey(correction: 32 + topPadding))
+                        .frame(height: 20)
                 }
+                
+                Stepper(onIncrement: { self.topPadding += 1},
+                        onDecrement: { self.topPadding -= 1 },
+                        label: { Text("Top padding: \(topPadding)") })
             }
+            
             Section(header: Text("1")) {
                 NavigationLink(destination: DetailView(title: "Nav")) {
                     Text("Some navigation")

--- a/StretchyScrollApp/StretchyScrollApp/ScrollViewExample.swift
+++ b/StretchyScrollApp/StretchyScrollApp/ScrollViewExample.swift
@@ -79,7 +79,7 @@ struct ScrollViewExample: View {
 
     var body: some View {
         ScrollViewContentView()
-            .modifier(StacyHeader(staticHeight: 64, extraHeight: 200, content: { desiredHeight in
+            .modifier(StacyHeader(staticHeight: 64, extraHeight: 100, content: { desiredHeight in
                 ScrollViewHeaderView(desiredHeight: desiredHeight)
             }))
     }
@@ -97,17 +97,17 @@ struct ScrollViewHeaderView: View {
                     .aspectRatio(1, contentMode: .fill)
                     .frame(height: self.desiredHeight)
                     .clipped()
-                    .opacity(Double((self.desiredHeight - 108) / 200))
+                    .opacity(Double((self.desiredHeight - proxy.safeAreaInsets.top - 64) / 100))
                 
                 VStack(spacing: 4) {
-                    Text("Height: \(self.desiredHeight)")
+                    Text("Height: \(self.desiredHeight - proxy.safeAreaInsets.top)")
                         .bold()
+                        .foregroundColor((self.desiredHeight - proxy.safeAreaInsets.top == 64) ? .black : .white)
                         .multilineTextAlignment(.center)
                         .font(.title)
                         .padding()
                     Divider()
                 }
-                .background(Color.white)
                 .padding(.top, proxy.safeAreaInsets.top)
             }
             .background(Color.white)


### PR DESCRIPTION
This PR contains an option to be able to handle headers with opened and closed heights.

The functionality to do so got outsourced to a `ViewModifier` as well as the logic of using `ScrollOffsetPreferenceKey`. 

The usage of this changed to

```swift
            Text("Top content")
                .modifier(ScrollOffsetPreferenceKey(correction: 32))
```
Where the text is inside the scrolling content, 32 points from the top.
To use a header modify the outer view by

```swift
        ScrollViewContentView()
            .modifier(StretcyHeader(staticHeight: 64, extraHeight: 100, content: { desiredHeight in
                ScrollViewHeaderView(desiredHeight: desiredHeight)
            }))
```

Where the height boundaries are set and the currently calculated height gets passed to the header view to render itself.